### PR TITLE
fix mixed content error for google fonts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap');
-
 *{
     margin :0;
     font-weight: 400;

--- a/assets/html/event.html
+++ b/assets/html/event.html
@@ -12,7 +12,7 @@
       <link href="../css/style.css" rel="stylesheet" type="text/css">
       <!-- style end -->
       <!-- google fonts start -->
-      <link href="http://fonts.googleapis.com/css?family=Poppins:400,400i,500,500i,600,600i,700,700i,800,800i,900,900i%7CRacing+Sans+One" rel="stylesheet" type="text/css">
+      <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&family=Racing+Sans+One&display=swap" rel="stylesheet">
       <!-- google fonts end -->
       <!-- Material ui cdn -->
       <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>

--- a/assets/html/project.html
+++ b/assets/html/project.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="../css/light.css" media="(prefers-color-scheme: no-preference), (prefers-color-scheme: light)">
       <!-- style end -->
       <!-- google fonts start -->
-      <link href="http://fonts.googleapis.com/css?family=Poppins:400,400i,500,500i,600,600i,700,700i,800,800i,900,900i%7CRacing+Sans+One" rel="stylesheet" type="text/css">
+      <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&family=Racing+Sans+One&display=swap" rel="stylesheet">
       <!-- google fonts end -->
       <!-- Material ui cdn -->
       <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>

--- a/assets/html/team.html
+++ b/assets/html/team.html
@@ -18,7 +18,7 @@
         <!-- style end -->
 
         <!-- google fonts start -->
-        <link href="http://fonts.googleapis.com/css?family=Poppins:400,400i,500,500i,600,600i,700,700i,800,800i,900,900i%7CRacing+Sans+One" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&family=Racing+Sans+One&display=swap" rel="stylesheet">
         <!-- google fonts end -->
 
         <!-- Material ui cdn -->

--- a/index.html
+++ b/index.html
@@ -50,10 +50,9 @@
     <!--Font Awesome end-->
 
     <!-- google fonts start -->
-    <link
-      href="http://fonts.googleapis.com/css?family=Poppins:400,400i,500,500i,600,600i,700,700i,800,800i,900,900i%7CRacing+Sans+One"
+    <link 
+      href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&family=Racing+Sans+One&display=swap"
       rel="stylesheet"
-      type="text/css"
     />
     <!-- google fonts end -->
   </head>


### PR DESCRIPTION
# Pull Request 
Fixes #211 

## Proposed Changes
- Re-add google fonts with https url
- Replaced link to css on each html file 
  - index.html, event.html, project.html, team.html

## Types of changes made
- Fixed Bug
- Added the following line to the head of each html file

```
<!-- google fonts start -->
    <link 
      href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,400;1,500;1,600;1,700;1,800;1,900&family=Racing+Sans+One&display=swap"
      rel="stylesheet"
    />
<!-- google fonts end -->
```

## Screenshots
- Console show error-free
![image](https://user-images.githubusercontent.com/12401186/96347521-06f74680-1057-11eb-8cc0-ccaf05c98e76.png)

- On projects page, was incorrectly using a bolder font because of the import (now a regular weight)
![image](https://user-images.githubusercontent.com/12401186/96353082-c19a3f80-107d-11eb-9089-56f2a638fc73.png)

## Checklist:
- [x] My code follows the Mentioned Guidelines for the project
- [x] I have self-reviewed the changes made
- [x] I have made the changes easy to understand by adding comments
- [x] My changes does not generate new warnings/errors
- [x] I have attached relevant screenshots to display the changes made
- [x] I have made the required changes to the documentations
