### PR TITLE
Fixes dark mode not applicable when clicked on contactUs or learn link

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -45,7 +45,7 @@
     });
 
     function colorTheme(pref){
-        const name = location.href.split("/").slice(-1)[0];
+        const name = location.pathname.split("/").slice(-1)[0];
         if(name==="" || name==="index.html")
             link.href="./assets/css/"+pref+".css";
         else


### PR DESCRIPTION
Fixes #238

# Pull Request 

## Proposed Changes
- Changed location.href to location.pathname, as pathname reads only the file name and disregards query parameters

## Types of changes made
- [x] Fixed Bug
- [ ] Added new Features
- [ ] Edited Documentations
- [ ] Enhanced the working of code
- [ ] Additional Changes
- *Mention any Additional Change here*

## Additional Info
Provide additional information(*if any*) you want to convey.

## Viability of Code
Describe the tests that you ran to verify the changes made. Mention the tests for easy reproducibility.
- NA

#### Mention(*if any*) specific Test Configurations used:
- Filmware version:
- Hardware: 
- Toolchain: 
- SDK: 

## Screenshots or GIFs (*if any*)
Attach screenshots of the changes made for easy reference.
Original | Updated
:-----:|:-----:
*Attach_Original_Screenshot* | *Attach_Updated_Screenshot*

## Checklist:
- [x] My code follows the Mentioned Guidelines for the project
- [x] I have self-reviewed the changes made
- [x] I have made the changes easy to understand by adding comments
- [x] My changes does not generate new warnings/errors
- [x] I have attached relevant screenshots to display the changes made
- [x] I have made the required changes to the documentations
